### PR TITLE
Fix a bug with Ghostscript path detection

### DIFF
--- a/printer.py
+++ b/printer.py
@@ -30,7 +30,7 @@ if os.name=='nt':
                 path=gsDir+os.sep+f
                 if os.path.isdir(path) and f.startswith('gs'):
                     try:
-                        val=float(f[2:])
+                        val=float(f[2:7]) # Example: if `f` equals to `gs10.03.0` then `f[2:7]` would give `10.03` which is what we expect.
                     except ValueError:
                         val=0.0
                     if bestVersion<val:


### PR DESCRIPTION
Fix the Ghostscript path detection when its installation path is like below:

```
C:\Program Files\gs\gs10.03.0\bin
```

![2024-04-17 10_11_08-bin](https://github.com/TheHeadlessSourceMan/virtualPrinter/assets/17475482/10561ba2-b6ea-4ca4-94d8-13f13ed652f8)
